### PR TITLE
fix: api ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fcm-service"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "gcp_auth",

--- a/src/domain/android_config/android_notification.rs
+++ b/src/domain/android_config/android_notification.rs
@@ -16,9 +16,9 @@ pub struct AndroidNotification {
     tag: Option<String>,
     click_action: Option<String>,
     body_loc_key: Option<String>,
-    body_loc_key_args: Option<Vec<String>>,
+    body_loc_args: Option<Vec<String>>,
     title_loc_key: Option<String>,
-    title_loc_key_args: Option<Vec<String>>,
+    title_loc_args: Option<Vec<String>>,
     channel_id: Option<String>,
     ticker: Option<String>,
     sticky: Option<bool>,
@@ -74,16 +74,16 @@ impl AndroidNotification {
         self.body_loc_key.as_ref()
     }
 
-    pub fn body_loc_key_args(&self) -> Option<&Vec<String>> {
-        self.body_loc_key_args.as_ref()
+    pub fn body_loc_args(&self) -> Option<&Vec<String>> {
+        self.body_loc_args.as_ref()
     }
 
     pub fn title_loc_key(&self) -> Option<&String> {
         self.title_loc_key.as_ref()
     }
 
-    pub fn title_loc_key_args(&self) -> Option<&Vec<String>> {
-        self.title_loc_key_args.as_ref()
+    pub fn title_loc_args(&self) -> Option<&Vec<String>> {
+        self.title_loc_args.as_ref()
     }
 
     pub fn channel_id(&self) -> Option<&String> {
@@ -182,16 +182,16 @@ impl AndroidNotification {
         self.body_loc_key = body_loc_key;
     }
 
-    pub fn set_body_loc_key_args(&mut self, body_loc_key_args: Option<Vec<String>>) {
-        self.body_loc_key_args = body_loc_key_args;
+    pub fn set_body_loc_args(&mut self, body_loc_args: Option<Vec<String>>) {
+        self.body_loc_args = body_loc_args;
     }
 
     pub fn set_title_loc_key(&mut self, title_loc_key: Option<String>) {
         self.title_loc_key = title_loc_key;
     }
 
-    pub fn set_title_loc_key_args(&mut self, title_loc_key_args: Option<Vec<String>>) {
-        self.title_loc_key_args = title_loc_key_args;
+    pub fn set_title_loc_args(&mut self, title_loc_args: Option<Vec<String>>) {
+        self.title_loc_args = title_loc_args;
     }
 
     pub fn set_channel_id(&mut self, channel_id: Option<String>) {


### PR DESCRIPTION
We got the following issue:

```sh
Failed to send new recipe topic messages, error: Failed to send notification: "{\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Invalid JSON payload received. Unknown name \\\"body_loc_key_args\\\" at 'message.android.notification': Cannot find field.\\nInvalid JSON payload received. Unknown name \\\"title_loc_key_args\\\" at 'message.android.notification': Cannot find field.\",\n    \"status\": \"INVALID_ARGUMENT\",\n    \"details\": [\n      {\n        \"@type\": \"type.googleapis.com/google.rpc.BadRequest\",\n        \"fieldViolations\": [\n          {\n            \"field\": \"message.android.notification\",\n            \"description\": \"Invalid JSON payload received. Unknown name \\\"body_loc_key_args\\\" at 'message.android.notification': Cannot find field.\"\n          },\n          {\n            \"field\": \"message.android.notification\",\n            \"description\": \"Invalid JSON payload received. Unknown name \\\"title_loc_key_args\\\" at 'message.android.notification': Cannot find field.\"\n          }\n        ]\n      }\n    ]\n  }\n}\n"
```

In the docs: https://firebase.google.com/docs/reference/cpp/struct/firebase/messaging/notification#structfirebase_1_1messaging_1_1_notification_1a8125da230f7cc9c5ca2b1e8168799ae3

`body_loc_args` instead of `body_loc_key_args` and `title_loc_args` instead of `title_loc_key_args`. If this fix is relevant can you please merge it?